### PR TITLE
change example class name to variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ By default we provide [container sizes](#configuration) from `@xs` (`20rem`) to 
 
 ### Named containers
 
-You can optionally name containers using a `@container/{name}` class, and then include that name in the container variants using classes like `@lg/main:underline`:
+You can optionally name containers using a `@container/{name}` class, and then include that name in the container variants using classes like `@lg/{name}:underline`:
 
 ```html
 <div class="@container/main">


### PR DESCRIPTION
I guess there is a typo on Named Containers section on Readme. Description have both {name} variable and example class name 'name' in it. Better to write variable names on both places in description.  