### PR TITLE
Add documentation for usage with class prefixes enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ In addition to using one of the [container sizes](#configuration) provided by de
 </div>
 ```
 
+## Usage with tailwind's prefix option enabled
+
+When your project has a `prefix` option set inside of the tailwind.config.js file, you need to add your prefix to the `@container` class like `tw-@container` if your prefix is `tw-`:
+
+```html
+<div class="tw-@container">
+  <div class="@lg:tw-underline">
+    <!-- This text will be underlined when the "main" container is larger than `32rem` -->
+  </div>
+</div>
+```
+
 ### Removing a container
 
 To stop an element from acting as a container, use the `@container-normal` class.


### PR DESCRIPTION
This may seem a little obvious but I wonder if it would be worth adding some instructions to the readme for using container queries with prefixes enabled in the config. It's sometimes easy to forget you need the prefix set on everything when using them. 😅 