### PR TITLE
Fix json syntax for customizing container size example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ module.exports = {
   theme: {
     extend: {
       containers: {
-        `2xs`: '16rem',
+        '2xs': '16rem',
       },
     },
   },


### PR DESCRIPTION
Using the original version of the example in a file ending with a `.cjs` syntax results in an error:

<img width="499" alt="Screenshot 2023-01-04 at 11 46 31 PM" src="https://user-images.githubusercontent.com/48997634/210622375-da9d2905-d2ac-4612-a76e-b2a743d44788.png">
