### PR TITLE
📐 Add support for min-height container queries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,8 @@ export = plugin(
       },
       {
         values: {
-          DEFAULT: 'inline-size',
+          DEFAULT: 'size',
+          'inline-size': 'inline-size',
           normal: 'normal',
         },
         modifiers: 'any',

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,8 @@ export = plugin(
     )
 
     matchVariant<string>('@', cbFor('min-width'), options)
-    matchVariant<string>('@w', cbFor('min-width'), options)
-    matchVariant<string>('@h', cbFor('min-height'), options)
+    matchVariant<string>('container-min-w', cbFor('min-width'), options)
+    matchVariant<string>('container-min-h', cbFor('min-height'), options)
   },
   {
     theme: {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,15 +14,15 @@ it('container queries', () => {
             <div class="@md/container2:underline"></div>
             <div class="@md/container10:underline"></div>
 
-            <div class="@w-md:underline"></div>
-            <div class="@w-md/container1:underline"></div>
-            <div class="@w-md/container2:underline"></div>
-            <div class="@w-md/container10:underline"></div>
+            <div class="container-min-w-md:underline"></div>
+            <div class="container-min-w-md/container1:underline"></div>
+            <div class="container-min-w-md/container2:underline"></div>
+            <div class="container-min-w-md/container10:underline"></div>
 
-            <div class="@h-md:underline"></div>
-            <div class="@h-md/container1:underline"></div>
-            <div class="@h-md/container2:underline"></div>
-            <div class="@h-md/container10:underline"></div>
+            <div class="container-min-h-md:underline"></div>
+            <div class="container-min-h-md/container1:underline"></div>
+            <div class="container-min-h-md/container2:underline"></div>
+            <div class="container-min-h-md/container10:underline"></div>
 
             <div class="@sm:underline"></div>
             <div class="@sm/container1:underline"></div>
@@ -41,13 +41,15 @@ it('container queries', () => {
             <div class="@[200rem]:underline"></div>
             <div class="@[123px]:underline"></div>
 
-            <div class="@w-[312px]:underline"></div>
-            <div class="@w-[200rem]:underline"></div>
-            <div class="@w-[123px]:underline"></div>
+            <div class="container-min-w-[312px]:underline"></div>
+            <div class="container-min-w-[200rem]:underline"></div>
+            <div class="container-min-w-[123px]:underline"></div>
+            <div class="container-min-w-[123px]/container1:underline"></div>
 
-            <div class="@h-[312px]:underline"></div>
-            <div class="@h-[200rem]:underline"></div>
-            <div class="@h-[123px]:underline"></div>
+            <div class="container-min-h-[312px]:underline"></div>
+            <div class="container-min-h-[200rem]:underline"></div>
+            <div class="container-min-h-[123px]:underline"></div>
+            <div class="container-min-h-[123px]/container1:underline"></div>
           </div>
         `,
       },
@@ -182,86 +184,98 @@ it('container queries', () => {
         }
       }
 
+      @container container1 (min-width: 123px) {
+        .container-min-w-\[123px\]\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
       @container (min-width: 123px) {
-        .\@w-\[123px\]\:underline {
+        .container-min-w-\[123px\]\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 200rem) {
-        .\@w-\[200rem\]\:underline {
+        .container-min-w-\[200rem\]\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 312px) {
-        .\@w-\[312px\]\:underline {
+        .container-min-w-\[312px\]\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container container1 (min-width: 768px) {
-        .\@w-md\/container1\:underline {
+        .container-min-w-md\/container1\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container container2 (min-width: 768px) {
-        .\@w-md\/container2\:underline {
+        .container-min-w-md\/container2\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container container10 (min-width: 768px) {
-        .\@w-md\/container10\:underline {
+        .container-min-w-md\/container10\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 768px) {
-        .\@w-md\:underline {
+        .container-min-w-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (min-height: 123px) {
+        .container-min-h-\[123px\]\/container1\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 123px) {
-        .\@h-\[123px\]\:underline {
+        .container-min-h-\[123px\]\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 200rem) {
-        .\@h-\[200rem\]\:underline {
+        .container-min-h-\[200rem\]\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 312px) {
-        .\@h-\[312px\]\:underline {
+        .container-min-h-\[312px\]\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container container1 (min-height: 768px) {
-        .\@h-md\/container1\:underline {
+        .container-min-h-md\/container1\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container container2 (min-height: 768px) {
-        .\@h-md\/container2\:underline {
+        .container-min-h-md\/container2\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container container10 (min-height: 768px) {
-        .\@h-md\/container10\:underline {
+        .container-min-h-md\/container10\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 768px) {
-        .\@h-md\:underline {
+        .container-min-h-md\:underline {
           text-decoration-line: underline;
         }
       }
@@ -284,23 +298,23 @@ it('should be possible to use default container queries', () => {
             <div class="@3xl:underline"></div>
             <div class="@5xl:underline"></div>
 
-            <div class="@w-md:underline"></div>
-            <div class="@w-lg:underline"></div>
-            <div class="@w-sm:underline"></div>
-            <div class="@w-xs:underline"></div>
-            <div class="@w-7xl:underline"></div>
-            <div class="@w-6xl:underline"></div>
-            <div class="@w-3xl:underline"></div>
-            <div class="@w-5xl:underline"></div>
+            <div class="container-min-w-md:underline"></div>
+            <div class="container-min-w-lg:underline"></div>
+            <div class="container-min-w-sm:underline"></div>
+            <div class="container-min-w-xs:underline"></div>
+            <div class="container-min-w-7xl:underline"></div>
+            <div class="container-min-w-6xl:underline"></div>
+            <div class="container-min-w-3xl:underline"></div>
+            <div class="container-min-w-5xl:underline"></div>
 
-            <div class="@h-md:underline"></div>
-            <div class="@h-lg:underline"></div>
-            <div class="@h-sm:underline"></div>
-            <div class="@h-xs:underline"></div>
-            <div class="@h-7xl:underline"></div>
-            <div class="@h-6xl:underline"></div>
-            <div class="@h-3xl:underline"></div>
-            <div class="@h-5xl:underline"></div>
+            <div class="container-min-h-md:underline"></div>
+            <div class="container-min-h-lg:underline"></div>
+            <div class="container-min-h-sm:underline"></div>
+            <div class="container-min-h-xs:underline"></div>
+            <div class="container-min-h-7xl:underline"></div>
+            <div class="container-min-h-6xl:underline"></div>
+            <div class="container-min-h-3xl:underline"></div>
+            <div class="container-min-h-5xl:underline"></div>
           </div>
         `,
       },
@@ -364,97 +378,97 @@ it('should be possible to use default container queries', () => {
       }
 
       @container (min-width: 20rem) {
-        .\@w-xs\:underline {
+        .container-min-w-xs\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 24rem) {
-        .\@w-sm\:underline {
+        .container-min-w-sm\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 28rem) {
-        .\@w-md\:underline {
+        .container-min-w-md\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 32rem) {
-        .\@w-lg\:underline {
+        .container-min-w-lg\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 48rem) {
-        .\@w-3xl\:underline {
+        .container-min-w-3xl\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 64rem) {
-        .\@w-5xl\:underline {
+        .container-min-w-5xl\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 72rem) {
-        .\@w-6xl\:underline {
+        .container-min-w-6xl\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-width: 80rem) {
-        .\@w-7xl\:underline {
+        .container-min-w-7xl\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 20rem) {
-        .\@h-xs\:underline {
+        .container-min-h-xs\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 24rem) {
-        .\@h-sm\:underline {
+        .container-min-h-sm\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 28rem) {
-        .\@h-md\:underline {
+        .container-min-h-md\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 32rem) {
-        .\@h-lg\:underline {
+        .container-min-h-lg\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 48rem) {
-        .\@h-3xl\:underline {
+        .container-min-h-3xl\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 64rem) {
-        .\@h-5xl\:underline {
+        .container-min-h-5xl\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 72rem) {
-        .\@h-6xl\:underline {
+        .container-min-h-6xl\:underline {
           text-decoration-line: underline;
         }
       }
 
       @container (min-height: 80rem) {
-        .\@h-7xl\:underline {
+        .container-min-h-7xl\:underline {
           text-decoration-line: underline;
         }
       }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,6 +14,16 @@ it('container queries', () => {
             <div class="@md/container2:underline"></div>
             <div class="@md/container10:underline"></div>
 
+            <div class="@w-md:underline"></div>
+            <div class="@w-md/container1:underline"></div>
+            <div class="@w-md/container2:underline"></div>
+            <div class="@w-md/container10:underline"></div>
+
+            <div class="@h-md:underline"></div>
+            <div class="@h-md/container1:underline"></div>
+            <div class="@h-md/container2:underline"></div>
+            <div class="@h-md/container10:underline"></div>
+
             <div class="@sm:underline"></div>
             <div class="@sm/container1:underline"></div>
             <div class="@sm/container2:underline"></div>
@@ -30,6 +40,14 @@ it('container queries', () => {
             <div class="@[312px]:underline"></div>
             <div class="@[200rem]:underline"></div>
             <div class="@[123px]:underline"></div>
+
+            <div class="@w-[312px]:underline"></div>
+            <div class="@w-[200rem]:underline"></div>
+            <div class="@w-[123px]:underline"></div>
+
+            <div class="@h-[312px]:underline"></div>
+            <div class="@h-[200rem]:underline"></div>
+            <div class="@h-[123px]:underline"></div>
           </div>
         `,
       },
@@ -163,6 +181,90 @@ it('container queries', () => {
           text-decoration-line: underline;
         }
       }
+
+      @container (min-width: 123px) {
+        .\@w-\[123px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 200rem) {
+        .\@w-\[200rem\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 312px) {
+        .\@w-\[312px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (min-width: 768px) {
+        .\@w-md\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (min-width: 768px) {
+        .\@w-md\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (min-width: 768px) {
+        .\@w-md\/container10\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 768px) {
+        .\@w-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 123px) {
+        .\@h-\[123px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 200rem) {
+        .\@h-\[200rem\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 312px) {
+        .\@h-\[312px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (min-height: 768px) {
+        .\@h-md\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (min-height: 768px) {
+        .\@h-md\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (min-height: 768px) {
+        .\@h-md\/container10\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 768px) {
+        .\@h-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
     `)
   })
 })
@@ -181,6 +283,24 @@ it('should be possible to use default container queries', () => {
             <div class="@6xl:underline"></div>
             <div class="@3xl:underline"></div>
             <div class="@5xl:underline"></div>
+
+            <div class="@w-md:underline"></div>
+            <div class="@w-lg:underline"></div>
+            <div class="@w-sm:underline"></div>
+            <div class="@w-xs:underline"></div>
+            <div class="@w-7xl:underline"></div>
+            <div class="@w-6xl:underline"></div>
+            <div class="@w-3xl:underline"></div>
+            <div class="@w-5xl:underline"></div>
+
+            <div class="@h-md:underline"></div>
+            <div class="@h-lg:underline"></div>
+            <div class="@h-sm:underline"></div>
+            <div class="@h-xs:underline"></div>
+            <div class="@h-7xl:underline"></div>
+            <div class="@h-6xl:underline"></div>
+            <div class="@h-3xl:underline"></div>
+            <div class="@h-5xl:underline"></div>
           </div>
         `,
       },
@@ -239,6 +359,102 @@ it('should be possible to use default container queries', () => {
 
       @container (min-width: 80rem) {
         .\@7xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 20rem) {
+        .\@w-xs\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 24rem) {
+        .\@w-sm\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 28rem) {
+        .\@w-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 32rem) {
+        .\@w-lg\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 48rem) {
+        .\@w-3xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 64rem) {
+        .\@w-5xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 72rem) {
+        .\@w-6xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-width: 80rem) {
+        .\@w-7xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 20rem) {
+        .\@h-xs\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 24rem) {
+        .\@h-sm\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 28rem) {
+        .\@h-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 32rem) {
+        .\@h-lg\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 48rem) {
+        .\@h-3xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 64rem) {
+        .\@h-5xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 72rem) {
+        .\@h-6xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (min-height: 80rem) {
+        .\@h-7xl\:underline {
           text-decoration-line: underline;
         }
       }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -7,7 +7,7 @@ it('container queries', () => {
       {
         raw: html`
           <div
-            class="@container @container-normal @container/sidebar @container-normal/sidebar @container-[size]/sidebar"
+            class="@container @container-normal @container/sidebar @container-normal/sidebar @container-[inline-size]/sidebar"
           >
             <div class="@md:underline"></div>
             <div class="@md/container1:underline"></div>
@@ -69,7 +69,7 @@ it('container queries', () => {
   return run(input, config).then((result) => {
     expect(result.css).toMatchFormattedCss(css`
       .\@container {
-        container-type: inline-size;
+        container-type: size;
       }
 
       .\@container-normal {
@@ -77,7 +77,7 @@ it('container queries', () => {
       }
 
       .\@container\/sidebar {
-        container-type: inline-size;
+        container-type: size;
         container-name: sidebar;
       }
 


### PR DESCRIPTION
This PR adds support for `min-height` on container queries. It does this by introducing new variants...
- `@` is retained for backwards compatibility and defaults to width
- ~`@w-`~ `container-min-w` is an alias of `@`
- ~`@h-`~ `container-min-h` is used to set a `min-height` container query

This is just a proposed approach and I'm totally open to a different one.

I have added some tests as well.

This is my first PR to Tailwind so let me know if you have any feedback or would like me to change anything.

Thanks!