### PR TITLE
Support of max-width container queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Added
+
+- Support of `max-width` container queries using `@max` or `atMax` variants.
 
 ## [0.1.1] - 2023-03-31
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Start by marking an element as a container using the `@container` class, and the
 
 By default we provide [container sizes](#configuration) from `@xs` (`20rem`) to `@7xl` (`80rem`).
 
+In case of `max-width` container queries:
+
+```html
+<div class="@container">
+  <div class="@max-lg:underline">
+    <!-- This text will be underlined when the container is larger than `32rem` -->
+  </div>
+</div>
+```
+
+or alternatively there is an `atMax` version:
+
+```html
+<div class="@container">
+  <div class="atMax-lg:underline">
+    <!-- This text will be underlined when the container is larger than `32rem` -->
+  </div>
+</div>
+```
+
 ### Named containers
 
 You can optionally name containers using a `@container/{name}` class, and then include that name in the container variants using classes like `@lg/{name}:underline`:
@@ -48,6 +68,26 @@ You can optionally name containers using a `@container/{name}` class, and then i
   <!-- ... -->
   <div class="@lg/main:underline">
     <!-- This text will be underlined when the "main" container is larger than `32rem` -->
+  </div>
+</div>
+```
+
+In case of `max-width` container queries:
+
+```html
+<div class="@container/main">
+  <div class="@max-lg/main:underline">
+    <!-- This text will be underlined when the container is larger than `32rem` -->
+  </div>
+</div>
+```
+
+or alternatively the `atMax` version:
+
+```html
+<div class="@container/main">
+  <div class="atMax-lg/main:underline">
+    <!-- This text will be underlined when the container is larger than `32rem` -->
   </div>
 </div>
 ```
@@ -63,6 +103,56 @@ In addition to using one of the [container sizes](#configuration) provided by de
   </div>
 </div>
 ```
+
+In case of `max-width` container queries:
+
+```html
+<div class="@container">
+  <div class="@max-[17.5rem]:underline">
+    <!-- This text will be underlined when the container is larger than `32rem` -->
+  </div>
+</div>
+```
+
+or alternatively the `atMax` version:
+
+```html
+<div class="@container">
+  <div class="atMax-[17.5rem]:underline">
+    <!-- This text will be underlined when the container is larger than `32rem` -->
+  </div>
+</div>
+```
+
+### Combining named containers and arbitrary container sizes
+
+You can combine both [named containers](#named-containers) and
+[arbitrary container sizes](#arbitrary-container-sizes) this way:
+
+```html
+<div class="@container/main">
+  <div class="@[17.5rem]/main:underline"></div>
+    <!-- This text will be underlined when the container is larger than `17.5rem` -->
+  </div>
+</div>
+```
+
+In case of `max-width` container queries only the `atMax` version is working
+because to support extraction of `@max-[17.5rem]/main:underline` by the default
+extractor of Tailwind CSS its regular expressions would need to be updated
+(or a custom extractor could be used but that is really an advanced topic since it
+overrides the default one which does really an excellent job to extract class name
+candidates from anywhere).
+
+```html
+<div class="@container/main">
+  <div class="atMax-[17.5rem]/main:underline">
+    <!-- This text will be underlined when the container is larger than `32rem` -->
+  </div>
+</div>
+```
+
+
 
 ### Removing a container
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,19 @@ export = plugin(
     }
 
     matchVariant(
+      '@',
+      (value = '', { modifier }) => {
+        let parsed = parseValue(value)
+
+        return parsed !== null ? `@container ${modifier ?? ''} (min-width: ${value})` : []
+      },
+      {
+        values,
+        sort,
+      }
+    )
+
+    matchVariant(
       '@max',
       (value = '', { modifier }) => {
         let parsed = parseValue(value)
@@ -71,11 +84,11 @@ export = plugin(
     )
 
     matchVariant(
-      '@',
+      'atMax',
       (value = '', { modifier }) => {
         let parsed = parseValue(value)
 
-        return parsed !== null ? `@container ${modifier ?? ''} (min-width: ${value})` : []
+        return parsed !== null ? `@container ${modifier ?? ''} (max-width: ${value})` : []
       },
       {
         values,

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,13 +70,15 @@ export = plugin(
       }
     )
 
+    const maxVariantFn: (value: string, { modifier }: { modifier: string | null }) => string | string[] = (value = '', { modifier }) => {
+      let parsed = parseValue(value)
+
+      return parsed !== null ? `@container ${modifier ?? ''} (max-width: ${value})` : []
+    }
+
     matchVariant(
       '@max',
-      (value = '', { modifier }) => {
-        let parsed = parseValue(value)
-
-        return parsed !== null ? `@container ${modifier ?? ''} (max-width: ${value})` : []
-      },
+      maxVariantFn,
       {
         values,
         sort,
@@ -85,11 +87,7 @@ export = plugin(
 
     matchVariant(
       'atMax',
-      (value = '', { modifier }) => {
-        let parsed = parseValue(value)
-
-        return parsed !== null ? `@container ${modifier ?? ''} (max-width: ${value})` : []
-      },
+      maxVariantFn,
       {
         values,
         sort,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@jest/globals'
 import { html, css, run } from './run'
+import _defaultExtractor from 'tailwindcss/lib/lib/defaultExtractor'
 
 it('container queries', () => {
   let config = {
@@ -239,6 +240,250 @@ it('should be possible to use default container queries', () => {
 
       @container (min-width: 80rem) {
         .\@7xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})
+
+it('max-width container queries', () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div
+            class="@container @container-normal @container/sidebar @container-normal/sidebar @container-[size]/sidebar"
+          >
+            <div class="@max-md:underline"></div>
+            <div class="@max-md/container1:underline"></div>
+            <div class="@max-md/container2:underline"></div>
+            <div class="@max-md/container10:underline"></div>
+
+            <div class="@max-sm:underline"></div>
+            <div class="@max-sm/container1:underline"></div>
+            <div class="@max-sm/container2:underline"></div>
+            <div class="@max-sm/container10:underline"></div>
+
+            <div class="@max-lg:underline"></div>
+            <div class="@max-lg/container1:underline"></div>
+            <div class="@max-lg/container2:underline"></div>
+            <div class="@max-lg/container10:underline"></div>
+            <div class="@max-[1024px]:underline"></div>
+<!--        These are not working with the current defaultExtractor:
+            <div class="@max-[1024px]/container1:underline"></div>
+            <div class="@max-[1024]/container1:underline"></div>
+-->
+
+            <div class="@max-[312px]:underline"></div>
+            <div class="@max-[200rem]:underline"></div>
+            <div class="@max-[123px]:underline"></div>
+          </div>
+        `,
+      },
+    ],
+    theme: {
+      containers: {
+        sm: '320px',
+        md: '768px',
+        lg: '1024px',
+      },
+    },
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\@container {
+        container-type: inline-size;
+      }
+
+      .\@container-normal {
+        container-type: normal;
+      }
+
+      .\@container\/sidebar {
+        container-type: inline-size;
+        container-name: sidebar;
+      }
+
+      .\@container-normal\/sidebar {
+        container-type: normal;
+        container-name: sidebar;
+      }
+
+      @container (max-width: 123px) {
+        .\@max-\[123px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 200rem) {
+        .\@max-\[200rem\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 312px) {
+        .\@max-\[312px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (max-width: 320px) {
+        .\@max-sm\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (max-width: 320px) {
+        .\@max-sm\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (max-width: 320px) {
+        .\@max-sm\/container10\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 320px) {
+        .\@max-sm\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (max-width: 768px) {
+        .\@max-md\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (max-width: 768px) {
+        .\@max-md\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (max-width: 768px) {
+        .\@max-md\/container10\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 768px) {
+        .\@max-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (max-width: 1024px) {
+        .\@max-lg\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (max-width: 1024px) {
+        .\@max-lg\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (max-width: 1024px) {
+        .\@max-lg\/container10\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 1024px) {
+        .\@max-lg\:underline {
+          text-decoration-line: underline;
+        }
+        .\@max-\[1024px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})
+
+it('should be possible to use default max-width container queries', () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div>
+            <div class="@max-md:underline"></div>
+            <div class="@max-lg:underline"></div>
+            <div class="@max-sm:underline"></div>
+            <div class="@max-xs:underline"></div>
+            <div class="@max-7xl:underline"></div>
+            <div class="@max-6xl:underline"></div>
+            <div class="@max-3xl:underline"></div>
+            <div class="@max-5xl:underline"></div>
+          </div>
+        `,
+      },
+    ],
+    theme: {},
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      @container (max-width: 20rem) {
+        .\@max-xs\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 24rem) {
+        .\@max-sm\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 28rem) {
+        .\@max-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 32rem) {
+        .\@max-lg\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 48rem) {
+        .\@max-3xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 64rem) {
+        .\@max-5xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 72rem) {
+        .\@max-6xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 80rem) {
+        .\@max-7xl\:underline {
           text-decoration-line: underline;
         }
       }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -489,3 +489,249 @@ it('should be possible to use default max-width container queries', () => {
     `)
   })
 })
+
+it('atMax max-width container queries', () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div
+            class="@container @container-normal @container/sidebar @container-normal/sidebar @container-[size]/sidebar"
+          >
+            <div class="atMax-md:underline"></div>
+            <div class="atMax-md/container1:underline"></div>
+            <div class="atMax-md/container2:underline"></div>
+            <div class="atMax-md/container10:underline"></div>
+
+            <div class="atMax-sm:underline"></div>
+            <div class="atMax-sm/container1:underline"></div>
+            <div class="atMax-sm/container2:underline"></div>
+            <div class="atMax-sm/container10:underline"></div>
+
+            <div class="atMax-lg:underline"></div>
+            <div class="atMax-lg/container1:underline"></div>
+            <div class="atMax-lg/container2:underline"></div>
+            <div class="atMax-lg/container10:underline"></div>
+            <div class="atMax-[1024px]:underline"></div>
+            <div class="atMax-[1024px]/container1:underline"></div>
+            <div class="atMax-[1024]/container1:underline"></div>
+
+            <div class="atMax-[312px]:underline"></div>
+            <div class="atMax-[200rem]:underline"></div>
+            <div class="atMax-[123px]:underline"></div>
+          </div>
+        `,
+      },
+    ],
+    theme: {
+      containers: {
+        sm: '320px',
+        md: '768px',
+        lg: '1024px',
+      },
+    },
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\@container {
+        container-type: inline-size;
+      }
+
+      .\@container-normal {
+        container-type: normal;
+      }
+
+      .\@container\/sidebar {
+        container-type: inline-size;
+        container-name: sidebar;
+      }
+
+      .\@container-normal\/sidebar {
+        container-type: normal;
+        container-name: sidebar;
+      }
+
+      @container (max-width: 123px) {
+        .atMax-\[123px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 200rem) {
+        .atMax-\[200rem\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 312px) {
+        .atMax-\[312px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (max-width: 320px) {
+        .atMax-sm\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (max-width: 320px) {
+        .atMax-sm\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (max-width: 320px) {
+        .atMax-sm\/container10\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 320px) {
+        .atMax-sm\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (max-width: 768px) {
+        .atMax-md\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (max-width: 768px) {
+        .atMax-md\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (max-width: 768px) {
+        .atMax-md\/container10\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 768px) {
+        .atMax-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container1 (max-width: 1024px) {
+        .atMax-lg\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      
+        .atMax-\[1024px\]\/container1\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container2 (max-width: 1024px) {
+        .atMax-lg\/container2\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container container10 (max-width: 1024px) {
+        .atMax-lg\/container10\:underline {
+          text-decoration-line: underline;
+        }
+    }
+
+      @container (max-width: 1024px) {
+        .atMax-lg\:underline {
+          text-decoration-line: underline;
+        }
+        .atMax-\[1024px\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})
+
+it('should be possible to use default atMax max-width container queries', () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div>
+            <div class="atMax-md:underline"></div>
+            <div class="atMax-lg:underline"></div>
+            <div class="atMax-sm:underline"></div>
+            <div class="atMax-xs:underline"></div>
+            <div class="atMax-7xl:underline"></div>
+            <div class="atMax-6xl:underline"></div>
+            <div class="atMax-3xl:underline"></div>
+            <div class="atMax-5xl:underline"></div>
+          </div>
+        `,
+      },
+    ],
+    theme: {},
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      @container (max-width: 20rem) {
+        .atMax-xs\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 24rem) {
+        .atMax-sm\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 28rem) {
+        .atMax-md\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 32rem) {
+        .atMax-lg\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 48rem) {
+        .atMax-3xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 64rem) {
+        .atMax-5xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 72rem) {
+        .atMax-6xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @container (max-width: 80rem) {
+        .atMax-7xl\:underline {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@jest/globals'
-import { html, css, run } from './run'
-import _defaultExtractor from 'tailwindcss/lib/lib/defaultExtractor'
+import { css, html, run } from './run'
 
 it('container queries', () => {
   let config = {


### PR DESCRIPTION
This PR implements support of max-width container queries using `@max` or `atMax` variants.

There are two variants because combination of arbitrary container sizes and named containers are not supported by the current default extractor. To support that case the `atMax` variant has been introduced (although the `@max` variant would be syntactically better and more aligned with the rest of the module).

README.md contains the usage including the edge case which is only supported by `atMax`. Unit tests has been added as well.

Thanks guys, you are really doing a good job with Tailwind CSS.