### PR TITLE
Make tailwindcss an optional peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
   "peerDependencies": {
     "tailwindcss": ">=3.2.0"
   },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.3.7",


### PR DESCRIPTION
We are using this package in an Elixir Phoenix project with the standalone tailwind cli. When installing this via npm, we import the whole dependency tree from tailwind. Would it be possible, to make this optional, so that standalone projects, can be kept lean?