### PR TITLE
docs: fix container-queries installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A plugin for Tailwind CSS v3.2+ that provides utilities for container queries.
 Install the plugin from npm:
 
 ```sh
-npm install @tailwindcss/container-queries
+npm install -D @tailwindcss/container-queries
 ```
 
 Then add the plugin to your `tailwind.config.js` file:


### PR DESCRIPTION
Updates the README to include the -D flag when installing @tailwindcss/container-queries package, making it consistent with Tailwind's recommended installation practice for plugins as dev dependencies.

Before:
npm install @tailwindcss/container-queries

After:
npm install -D @tailwindcss/container-queries